### PR TITLE
Register the credential-helper task with battery-safe settings

### DIFF
--- a/degdid.ps1
+++ b/degdid.ps1
@@ -2294,12 +2294,16 @@ if (`$delete) {
     -UserId $UserId `
     -LogonType $LogonType `
     -RunLevel $RunLevel
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries
 
   try {
     Register-ScheduledTask `
       -TaskName $taskName `
       -Action $action `
       -Principal $principal `
+      -Settings $settings `
       -Force `
       -ErrorAction Stop | Out-Null
     Start-ScheduledTask -TaskName $taskName -ErrorAction Stop


### PR DESCRIPTION
Fixes #2

### Problem
`Invoke-CredentialTask` registers its scheduled task without `-Settings`, so it inherits
the default `DisallowStartIfOnBatteries = $true`. On battery, Task Scheduler skips the
action: the task reports `LastTaskResult = 0` and writes no result file, so both `-Status`
and `-Protect` fail the device-credential inventory, and `-Protect` aborts before any
mutation.

### Change
Register the task with `New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
-DontStopIfGoingOnBatteries` so the helper runs regardless of power state. Nothing else
changes.

### Testing
Verified on Windows 11 24H2 (build 26100), PowerShell 7.6.4: on battery, `-Protect` now
completes the credential inventory and wipes; on AC, behavior is unchanged.
