### PR TITLE
Add -HostNatSafe wlidsvc scoping, with mint-scope refresh and answer filtering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep line endings LF everywhere so Windows core.autocrlf cannot rewrite
+# checkouts to CRLF and surface phantom whole-file diffs. All tracked files are
+# already LF, so this changes no blobs; it only pins working-tree handling.
+* text=auto eol=lf

--- a/degdid.ps1
+++ b/degdid.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 <#
 .SYNOPSIS
   Inspect, block, wipe, decoy, or unblock Microsoft GDID state on a supported

--- a/degdid.ps1
+++ b/degdid.ps1
@@ -48,6 +48,13 @@
   Inspect and report planned work without changing hosts, firewall, services,
   registry, or files. DryRun never claims that planned blocks are active.
 
+.PARAMETER HostNatSafe
+  Scope the wlidsvc DeviceAdd firewall deny to the mint host IPs instead of
+  all remote addresses. Keeps the hosts sinkhole and an IP-scoped service deny
+  (so the mint stays blocked at two layers) while no longer matching
+  NAT-forwarded traffic from Hyper-V / ICS guests. Use on a host that shares
+  its connection to VMs. Default protection is unchanged without this switch.
+
 .PARAMETER Json
   Emit Status as JSON.
 
@@ -91,6 +98,8 @@ param(
 
   [switch]$DryRun,
 
+  [switch]$HostNatSafe,
+
   [Parameter(DontShow = $true)]
   [switch]$InternalNoExit
 )
@@ -107,6 +116,7 @@ $script:StagingMintServiceRuleName = 'degdid-stage-wlidsvc-v2'
 $script:StagingMintServiceRuleDisplayName = 'degdid-stage-wlidsvc-v2'
 $script:FirewallGroup = 'degdid managed registration blocks'
 $script:MintHost = 'login.live.com'
+$script:HostNatSafeMode = $false
 $script:SettleSeconds = 12
 $script:DegdidExitCode = 0
 $script:Windows10SupportedBuild = 19045
@@ -1190,21 +1200,58 @@ function Remove-StagingMintServiceRule {
   }
 }
 
+function Get-MintScopeAddress {
+  # Real DeviceAdd mint-host IPs, resolved past the hosts sinkhole. Used to
+  # scope the wlidsvc deny under HostNatSafe so it blocks the mint without
+  # matching NAT-forwarded VM traffic. Returns empty when offline or
+  # unresolvable, in which case callers keep the all-remote fail-closed deny.
+  $addresses = New-Object System.Collections.Generic.List[string]
+  foreach ($recordType in @('A', 'AAAA')) {
+    try {
+      $answers = @(
+        Resolve-DnsName `
+          -Name $script:MintHost `
+          -Type $recordType `
+          -DnsOnly `
+          -NoHostsFile `
+          -QuickTimeout `
+          -ErrorAction Stop |
+          Where-Object { $_.IPAddress } |
+          ForEach-Object { $_.IPAddress }
+      )
+      foreach ($answer in $answers) {
+        if ($answer) { [void]$addresses.Add($answer) }
+      }
+    } catch {
+      # Unresolvable record type; caller falls back to the all-remote deny.
+    }
+  }
+  return @($addresses | Select-Object -Unique)
+}
+
 function New-StagingMintServiceRule {
   Remove-StagingMintServiceRule
-  New-NetFirewallRule `
-    -Name $script:StagingMintServiceRuleName `
-    -DisplayName $script:StagingMintServiceRuleDisplayName `
-    -Group $script:FirewallGroup `
-    -Description 'degdid temporary fail-closed wlidsvc deny during refresh' `
-    -Direction Outbound `
-    -Action Block `
-    -Enabled True `
-    -Profile Any `
-    -Protocol Any `
-    -Program (Join-Path $env:SystemRoot 'System32\svchost.exe') `
-    -Service 'wlidsvc' `
-    -ErrorAction Stop | Out-Null
+  $stagingRule = @{
+    Name = $script:StagingMintServiceRuleName
+    DisplayName = $script:StagingMintServiceRuleDisplayName
+    Group = $script:FirewallGroup
+    Description = 'degdid temporary fail-closed wlidsvc deny during refresh'
+    Direction = 'Outbound'
+    Action = 'Block'
+    Enabled = 'True'
+    Profile = 'Any'
+    Protocol = 'Any'
+    Program = (Join-Path $env:SystemRoot 'System32\svchost.exe')
+    Service = 'wlidsvc'
+    ErrorAction = 'Stop'
+  }
+  if ($script:HostNatSafeMode) {
+    $mintScope = @(Get-MintScopeAddress)
+    if ($mintScope.Count -gt 0) {
+      $stagingRule['RemoteAddress'] = $mintScope
+    }
+  }
+  New-NetFirewallRule @stagingRule | Out-Null
 }
 
 function Test-StagingMintServiceRuleEnforced {
@@ -1316,7 +1363,12 @@ function Set-FirewallBlock {
 
   try {
     $existingState = Get-FirewallState
-    $preserveMintService = [bool]$existingState.MintServiceRuleValid
+    # HostNatSafe must always (re)create the scoped deny rather than
+    # preserve a possibly all-remote rule left by a prior default run.
+    $preserveMintService = (
+      -not $script:HostNatSafeMode -and
+      [bool]$existingState.MintServiceRuleValid
+    )
     Remove-StagingMintServiceRule
     Remove-ManagedFirewallRules `
       -PreserveMintServiceRule:$preserveMintService
@@ -1349,19 +1401,29 @@ function Set-FirewallBlock {
       -ErrorAction Stop | Out-Null
 
     if (-not $preserveMintService) {
-      New-NetFirewallRule `
-        -Name $script:MintServiceRuleName `
-        -DisplayName $script:MintServiceRuleDisplayName `
-        -Group $script:FirewallGroup `
-        -Description 'degdid blocks all wlidsvc outbound DeviceAdd traffic' `
-        -Direction Outbound `
-        -Action Block `
-        -Enabled True `
-        -Profile Any `
-        -Protocol Any `
-        -Program (Join-Path $env:SystemRoot 'System32\svchost.exe') `
-        -Service 'wlidsvc' `
-        -ErrorAction Stop | Out-Null
+      $mintServiceRule = @{
+        Name = $script:MintServiceRuleName
+        DisplayName = $script:MintServiceRuleDisplayName
+        Group = $script:FirewallGroup
+        Description = 'degdid blocks all wlidsvc outbound DeviceAdd traffic'
+        Direction = 'Outbound'
+        Action = 'Block'
+        Enabled = 'True'
+        Profile = 'Any'
+        Protocol = 'Any'
+        Program = (Join-Path $env:SystemRoot 'System32\svchost.exe')
+        Service = 'wlidsvc'
+        ErrorAction = 'Stop'
+      }
+      if ($script:HostNatSafeMode) {
+        $mintScope = @(Get-MintScopeAddress)
+        if ($mintScope.Count -gt 0) {
+          $mintServiceRule['RemoteAddress'] = $mintScope
+          $mintServiceRule['Description'] =
+            'degdid blocks wlidsvc outbound to the DeviceAdd mint host (HostNatSafe scope)'
+        }
+      }
+      New-NetFirewallRule @mintServiceRule | Out-Null
     }
 
     # Hosts entries intentionally suppress normal DNS. Generate explicit
@@ -4595,6 +4657,7 @@ function Write-MutationResult {
 }
 
 function Invoke-DegdidMain {
+  $script:HostNatSafeMode = [bool]$HostNatSafe
   if (-not ($Status -or $Wipe -or $Decoy -or $Block -or $Unblock -or $Protect)) {
     $script:Status = $true
   }

--- a/degdid.ps1
+++ b/degdid.ps1
@@ -55,6 +55,21 @@
   NAT-forwarded traffic from Hyper-V / ICS guests. Use on a host that shares
   its connection to VMs. Default protection is unchanged without this switch.
 
+  The IP scope is a point-in-time snapshot. It is refreshed on every -Block, but
+  the mint host is CDN-fronted and its addresses rotate, and the AutoResolve
+  keyword cannot re-hydrate while the hosts sinkhole suppresses resolution. The
+  hosts sinkhole is the durable, rotation-proof layer; the IP-scoped deny is
+  best-effort defense in depth. Re-run -Block or -RefreshMintScope (schedule the
+  latter if you rely on the firewall layer) to keep the scope current.
+
+.PARAMETER RefreshMintScope
+  Re-resolve login.live.com and re-scope the standing wlidsvc deny to the fresh
+  address set, without touching hosts, keywords, or identity state. Companion to
+  -HostNatSafe for CDN IP rotation; run it periodically, for example from a
+  scheduled task. Requires an elevated administrator PowerShell. When the mint
+  host cannot be resolved to a routable address, the existing rule is left
+  unchanged rather than reverted to the all-remote deny.
+
 .PARAMETER Json
   Emit Status as JSON.
 
@@ -86,6 +101,9 @@ param(
 
   [Parameter(ParameterSetName = 'Unblock')]
   [switch]$Unblock,
+
+  [Parameter(ParameterSetName = 'RefreshMintScope')]
+  [switch]$RefreshMintScope,
 
   [Parameter(ParameterSetName = 'Protect')]
   [switch]$Protect,
@@ -1277,6 +1295,32 @@ function New-StagingMintServiceRule {
   New-NetFirewallRule @stagingRule | Out-Null
 }
 
+function New-PermanentMintServiceRule {
+  $mintServiceRule = @{
+    Name = $script:MintServiceRuleName
+    DisplayName = $script:MintServiceRuleDisplayName
+    Group = $script:FirewallGroup
+    Description = 'degdid blocks all wlidsvc outbound DeviceAdd traffic'
+    Direction = 'Outbound'
+    Action = 'Block'
+    Enabled = 'True'
+    Profile = 'Any'
+    Protocol = 'Any'
+    Program = (Join-Path $env:SystemRoot 'System32\svchost.exe')
+    Service = 'wlidsvc'
+    ErrorAction = 'Stop'
+  }
+  if ($script:HostNatSafeMode) {
+    $mintScope = @(Get-MintScopeAddress)
+    if ($mintScope.Count -gt 0) {
+      $mintServiceRule['RemoteAddress'] = $mintScope
+      $mintServiceRule['Description'] =
+        'degdid blocks wlidsvc outbound to the DeviceAdd mint host (HostNatSafe scope)'
+    }
+  }
+  New-NetFirewallRule @mintServiceRule | Out-Null
+}
+
 function Test-StagingMintServiceRuleEnforced {
   try {
     $rules = @(
@@ -1424,29 +1468,7 @@ function Set-FirewallBlock {
       -ErrorAction Stop | Out-Null
 
     if (-not $preserveMintService) {
-      $mintServiceRule = @{
-        Name = $script:MintServiceRuleName
-        DisplayName = $script:MintServiceRuleDisplayName
-        Group = $script:FirewallGroup
-        Description = 'degdid blocks all wlidsvc outbound DeviceAdd traffic'
-        Direction = 'Outbound'
-        Action = 'Block'
-        Enabled = 'True'
-        Profile = 'Any'
-        Protocol = 'Any'
-        Program = (Join-Path $env:SystemRoot 'System32\svchost.exe')
-        Service = 'wlidsvc'
-        ErrorAction = 'Stop'
-      }
-      if ($script:HostNatSafeMode) {
-        $mintScope = @(Get-MintScopeAddress)
-        if ($mintScope.Count -gt 0) {
-          $mintServiceRule['RemoteAddress'] = $mintScope
-          $mintServiceRule['Description'] =
-            'degdid blocks wlidsvc outbound to the DeviceAdd mint host (HostNatSafe scope)'
-        }
-      }
-      New-NetFirewallRule @mintServiceRule | Out-Null
+      New-PermanentMintServiceRule
     }
 
     # Hosts entries intentionally suppress normal DNS. Generate explicit
@@ -1525,6 +1547,83 @@ function Remove-FirewallBlock {
     Success = $state.Health -eq 'Absent'
     DryRun = $false
     Message = 'Managed firewall rules and keywords removed.'
+    State = $state
+  }
+}
+
+function Invoke-MintScopeRefresh {
+  param([switch]$DryRun)
+
+  # Re-resolve the DeviceAdd mint host and re-scope the standing wlidsvc deny to
+  # the fresh address set. This is the HostNatSafe companion for CDN IP rotation:
+  # the scoped rule is a point-in-time snapshot, and the AutoResolve keyword
+  # cannot re-hydrate under the hosts sinkhole, so a periodic re-resolve is the
+  # only way to keep the scope current without reverting to the all-remote deny.
+  if (-not (Test-DynamicFirewallSupport)) {
+    return [pscustomobject]@{
+      Success = $false
+      ExitCode = 3
+      Message = 'Dynamic-keyword firewall cmdlets are unavailable; mint scope was not refreshed.'
+      State = Get-FirewallState
+    }
+  }
+
+  $scope = @(Get-MintScopeAddress)
+  if ($DryRun) {
+    return [pscustomobject]@{
+      Success = $true
+      ExitCode = 0
+      Message = 'Would re-scope the wlidsvc deny to {0} resolved mint address(es); current state was not changed.' -f $scope.Count
+      State = Get-FirewallState
+    }
+  }
+  if ($scope.Count -eq 0) {
+    # A transient resolve failure must not clobber a good scope into all-remote.
+    return [pscustomobject]@{
+      Success = $true
+      ExitCode = 0
+      Message = 'The mint host resolved to no routable address; the existing wlidsvc rule was left unchanged.'
+      State = Get-FirewallState
+    }
+  }
+
+  try {
+    # Stage a fail-closed deny so wlidsvc stays blocked during the swap, verify
+    # it independently, then replace the standing rule with the fresh scope.
+    New-StagingMintServiceRule
+    if (-not (Wait-StagingMintServiceRuleEnforced)) {
+      throw 'The fail-closed staging deny is not enforced; the mint scope was not refreshed.'
+    }
+    foreach (
+      $rule in @(
+        Get-NetFirewallRule `
+          -Name $script:MintServiceRuleName `
+          -ErrorAction SilentlyContinue
+      )
+    ) {
+      Remove-NetFirewallRule -InputObject $rule -ErrorAction Stop
+    }
+    New-PermanentMintServiceRule
+    if (-not (Wait-PermanentMintServiceRuleEnforced)) {
+      throw 'The refreshed wlidsvc rule is not actively enforced.'
+    }
+    Remove-StagingMintServiceRule
+  } catch {
+    # The staging deny is intentionally left in place on failure: it keeps
+    # wlidsvc blocked (fail-closed) until the next -Block or refresh.
+    return [pscustomobject]@{
+      Success = $false
+      ExitCode = 3
+      Message = $_.Exception.Message
+      State = Get-FirewallState
+    }
+  }
+
+  $state = Get-FirewallState
+  return [pscustomobject]@{
+    Success = [bool]$state.MintServiceRuleValid
+    ExitCode = $(if ($state.MintServiceRuleValid) { 0 } else { 3 })
+    Message = 'Re-scoped the wlidsvc deny to {0} resolved mint address(es).' -f $scope.Count
     State = $state
   }
 }
@@ -4680,8 +4779,13 @@ function Write-MutationResult {
 }
 
 function Invoke-DegdidMain {
-  $script:HostNatSafeMode = [bool]$HostNatSafe
-  if (-not ($Status -or $Wipe -or $Decoy -or $Block -or $Unblock -or $Protect)) {
+  $script:HostNatSafeMode = ([bool]$HostNatSafe -or [bool]$RefreshMintScope)
+  if (
+    -not (
+      $Status -or $Wipe -or $Decoy -or $Block -or
+      $Unblock -or $Protect -or $RefreshMintScope
+    )
+  ) {
     $script:Status = $true
   }
 
@@ -4711,6 +4815,24 @@ function Invoke-DegdidMain {
       Write-Output 'DryRun: no hosts or firewall state was changed.'
     } elseif ($result.Success) {
       Write-Output 'Warning: a future DeviceAdd can mint a real GDID.'
+    }
+    $script:DegdidExitCode = $result.ExitCode
+    return
+  }
+
+  # Mint-scope refresh touches only the degdid-owned wlidsvc firewall deny, not
+  # identity stores, so it stays available like Unblock regardless of managed,
+  # multi-profile, or interactive-user state.
+  if ($RefreshMintScope) {
+    if (-not $DryRun -and -not (Test-IsAdministrator)) {
+      Write-Output 'Refused: RefreshMintScope requires an elevated administrator PowerShell.'
+      $script:DegdidExitCode = 1
+      return
+    }
+    $result = Invoke-MintScopeRefresh -DryRun:$DryRun
+    Write-Output $result.Message
+    if ($DryRun) {
+      Write-Output 'DryRun: no firewall state was changed.'
     }
     $script:DegdidExitCode = $result.ExitCode
     return

--- a/degdid.ps1
+++ b/degdid.ps1
@@ -1200,11 +1200,32 @@ function Remove-StagingMintServiceRule {
   }
 }
 
+function Test-RoutableMintAddress {
+  param([AllowNull()][string]$Address)
+
+  # A resolver-level sinkhole (router / Pi-hole / NextDNS) answers login.live.com
+  # with 0.0.0.0, ::, or a loopback address even when -NoHostsFile bypasses the
+  # local hosts file. Treat those as "not a real mint IP" so the scope never
+  # pins the deny to a non-routable address.
+  $parsed = $null
+  if (-not [System.Net.IPAddress]::TryParse($Address, [ref]$parsed)) {
+    return $false
+  }
+  if ([System.Net.IPAddress]::IsLoopback($parsed)) {
+    return $false
+  }
+  return (@($parsed.GetAddressBytes() | Where-Object { $_ -ne 0 }).Count -gt 0)
+}
+
 function Get-MintScopeAddress {
   # Real DeviceAdd mint-host IPs, resolved past the hosts sinkhole. Used to
   # scope the wlidsvc deny under HostNatSafe so it blocks the mint without
-  # matching NAT-forwarded VM traffic. Returns empty when offline or
-  # unresolvable, in which case callers keep the all-remote fail-closed deny.
+  # matching NAT-forwarded VM traffic. Unspecified (0.0.0.0 / ::) and loopback
+  # answers - what a resolver-level sinkhole hands back - are dropped so the
+  # scope is never pinned to a non-routable address; the set then stays empty
+  # and callers keep the all-remote fail-closed deny. The scope is a
+  # point-in-time snapshot, only as current as this resolve. Returns empty when
+  # offline or unresolvable.
   $addresses = New-Object System.Collections.Generic.List[string]
   foreach ($recordType in @('A', 'AAAA')) {
     try {
@@ -1220,7 +1241,9 @@ function Get-MintScopeAddress {
           ForEach-Object { $_.IPAddress }
       )
       foreach ($answer in $answers) {
-        if ($answer) { [void]$addresses.Add($answer) }
+        if (Test-RoutableMintAddress -Address $answer) {
+          [void]$addresses.Add($answer)
+        }
       }
     } catch {
       # Unresolvable record type; caller falls back to the all-remote deny.

--- a/tests/degdid.Tests.ps1
+++ b/tests/degdid.Tests.ps1
@@ -990,3 +990,33 @@ Describe 'degdid Unblock sequencing' {
     Assert-MockCalled Invoke-DnsFlush 0 -Scope It
   }
 }
+
+Describe 'degdid mint scope address hygiene' {
+  It 'accepts routable IPv4 and IPv6 answers' {
+    (Test-RoutableMintAddress -Address '40.126.31.1') | Should Be $true
+    (Test-RoutableMintAddress -Address '2620:1ec:4::1') | Should Be $true
+  }
+
+  It 'rejects unspecified, loopback, and unparseable answers' {
+    (Test-RoutableMintAddress -Address '0.0.0.0') | Should Be $false
+    (Test-RoutableMintAddress -Address '::') | Should Be $false
+    (Test-RoutableMintAddress -Address '127.0.0.1') | Should Be $false
+    (Test-RoutableMintAddress -Address '::1') | Should Be $false
+    (Test-RoutableMintAddress -Address 'not-an-ip') | Should Be $false
+    (Test-RoutableMintAddress -Address $null) | Should Be $false
+  }
+
+  It 'drops sinkhole answers from the resolved mint scope' {
+    Mock Resolve-DnsName {
+      @(
+        [pscustomobject]@{ IPAddress = '40.126.31.1' }
+        [pscustomobject]@{ IPAddress = '0.0.0.0' }
+        [pscustomobject]@{ IPAddress = '127.0.0.1' }
+      )
+    }
+    $scope = @(Get-MintScopeAddress)
+    ($scope -contains '40.126.31.1') | Should Be $true
+    ($scope -contains '0.0.0.0') | Should Be $false
+    ($scope -contains '127.0.0.1') | Should Be $false
+  }
+}

--- a/tests/degdid.Tests.ps1
+++ b/tests/degdid.Tests.ps1
@@ -1020,3 +1020,65 @@ Describe 'degdid mint scope address hygiene' {
     ($scope -contains '127.0.0.1') | Should Be $false
   }
 }
+
+Describe 'degdid mint scope refresh' {
+  It 'exposes the RefreshMintScope switch' {
+    $parameters = @((Get-Command $scriptPath).Parameters.Keys)
+    ($parameters -contains 'RefreshMintScope') | Should Be $true
+  }
+
+  It 'plans a refresh under DryRun without recreating the rule' {
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-MintScopeAddress { @('40.126.31.1') }
+    Mock Get-FirewallState { [pscustomobject]@{ MintServiceRuleValid = $true } }
+    Mock New-StagingMintServiceRule {}
+    Mock New-PermanentMintServiceRule {}
+    $result = Invoke-MintScopeRefresh -DryRun
+    $result.Success | Should Be $true
+    $result.ExitCode | Should Be 0
+    Assert-MockCalled New-PermanentMintServiceRule -Times 0 -Exactly -Scope It
+  }
+
+  It 'leaves the rule unchanged when nothing routable resolves' {
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-MintScopeAddress { @() }
+    Mock Get-FirewallState { [pscustomobject]@{ MintServiceRuleValid = $true } }
+    Mock New-PermanentMintServiceRule {}
+    $result = Invoke-MintScopeRefresh
+    $result.ExitCode | Should Be 0
+    $result.Message | Should Match 'left unchanged'
+    Assert-MockCalled New-PermanentMintServiceRule -Times 0 -Exactly -Scope It
+  }
+
+  It 're-scopes behind a fail-closed staging deny on success' {
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-MintScopeAddress { @('40.126.31.1') }
+    Mock New-StagingMintServiceRule {}
+    Mock Wait-StagingMintServiceRuleEnforced { $true }
+    Mock Get-NetFirewallRule { @() }
+    Mock Remove-NetFirewallRule {}
+    Mock New-PermanentMintServiceRule {}
+    Mock Wait-PermanentMintServiceRuleEnforced { $true }
+    Mock Remove-StagingMintServiceRule {}
+    Mock Get-FirewallState { [pscustomobject]@{ MintServiceRuleValid = $true } }
+    $result = Invoke-MintScopeRefresh
+    $result.Success | Should Be $true
+    $result.ExitCode | Should Be 0
+    Assert-MockCalled New-StagingMintServiceRule -Times 1 -Exactly -Scope It
+    Assert-MockCalled New-PermanentMintServiceRule -Times 1 -Exactly -Scope It
+    Assert-MockCalled Remove-StagingMintServiceRule -Times 1 -Exactly -Scope It
+  }
+
+  It 'fails closed when the staging deny is not enforced' {
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-MintScopeAddress { @('40.126.31.1') }
+    Mock New-StagingMintServiceRule {}
+    Mock Wait-StagingMintServiceRuleEnforced { $false }
+    Mock New-PermanentMintServiceRule {}
+    Mock Get-FirewallState { [pscustomobject]@{ MintServiceRuleValid = $false } }
+    $result = Invoke-MintScopeRefresh
+    $result.Success | Should Be $false
+    $result.ExitCode | Should Be 3
+    Assert-MockCalled New-PermanentMintServiceRule -Times 0 -Exactly -Scope It
+  }
+}


### PR DESCRIPTION
Fixes #3

### Problem
Run on a host that NATs a downstream network through the Windows stack (Hyper-V Default
Switch / NAT, ICS, WSL2), `-Protect` kills the shared clients' internet. The wlidsvc
DeviceAdd denies (`degdid-block-wlidsvc-v2` and the transient `degdid-stage-wlidsvc-v2`)
block `remote = Any`, which also matches the traffic the host re-originates when
NAT-forwarding its clients. The hosts sinkhole already blocks `login.live.com` for
wlidsvc, so on a NAT-sharing host this firewall belt is the only thing breaking clients.

Scoping a CDN-fronted host to resolved IPs then leaves two follow-on gaps:
- `login.live.com` is CDN-fronted, so its addresses rotate. The IP scope is a
  point-in-time snapshot, and the AutoResolve firewall keyword cannot re-hydrate while the
  hosts sinkhole suppresses resolution, so the scoped deny drifts stale between runs.
- `Get-MintScopeAddress` resolves with `-NoHostsFile`, which bypasses the local hosts file
  but not a resolver-level sinkhole (router / Pi-hole / NextDNS). Such a resolver answers
  with `0.0.0.0`/`::` or a loopback address, which would pin the deny to a non-routable
  address and silently reduce the service-layer block to a no-op.

### Change
Add an opt-in `-HostNatSafe` switch. When set, both wlidsvc denies are scoped to
`login.live.com`'s resolved IPs (`-RemoteAddress`) instead of all remote addresses, so the
mint stays blocked at two layers (hosts sinkhole plus the IP-scoped rule) while
NAT-forwarded client traffic to other destinations is no longer matched. If the mint host
can't be resolved (offline), it falls back to the original all-remote deny.
`Set-FirewallBlock` also stops preserving an existing rule when the switch is set, so it
always re-creates the scoped deny instead of keeping a prior all-remote one.

Alongside that:
- Filter unspecified and loopback answers out of `Get-MintScopeAddress`, so a
  resolver-level sinkhole can no longer scope the deny to a non-routable address. When
  nothing routable resolves, the set is empty and callers keep the all-remote fail-closed
  deny, matching the function's stated intent.
- Add `-RefreshMintScope`: re-resolve `login.live.com` and re-scope the standing wlidsvc
  deny in place, behind a fail-closed staging deny during the swap. It touches only
  degdid-owned firewall state, so it stays available like `-Unblock` regardless of managed
  or multi-profile state, and requires elevation. A transient resolve failure leaves the
  existing rule unchanged rather than clobbering a good scope. Run it periodically (for
  example from a scheduled task) to track CDN rotation.
- Extract the standing wlidsvc rule into `New-PermanentMintServiceRule`, shared by
  `Set-FirewallBlock` and the refresh so both build the identical rule.

Default behavior is unchanged: without `-HostNatSafe`, the rules are byte-identical to
before.

### Design notes
- `remote = Any` is deliberate as a fail-closed belt when the hosts sinkhole is bypassed
  or DNS can't resolve. Scoping trades a small part of that belt (a wlidsvc connection to
  a raw IP outside DNS) for host-NAT compatibility, which is why it's opt-in and off by
  default.
- Both the permanent and staging rules are scoped, so a wipe's fail-closed window doesn't
  break sharing either.
- Scoping to the FQDN dynamic keyword instead of static IPs was considered and rejected:
  under the hosts sinkhole the keyword's only hydration is degdid's own `-NoHostsFile`
  resolve at `-Block` time, so it is empty in exactly the window the wlidsvc backstop
  exists for. Static IPs (kept fresh by `-Block` / `-RefreshMintScope`) are the reliable
  scope; the hosts sinkhole remains the durable, rotation-proof layer.

### Repo hygiene (orthogonal, splittable)
This branch also drops the UTF-8 BOM from `degdid.ps1` (the body is pure ASCII, so the BOM
carried no information and made editors flag line 1 on every diff) and adds a
`.gitattributes` pinning text files to LF. These are unrelated to HostNatSafe and can be
lifted into a separate PR if preferred.

### Testing
Verified end-to-end on Windows 11 24H2 (build 26100), PowerShell 7.6.4, on a Hyper-V host
sharing to a VM: with `-HostNatSafe`, `-Block` and `-Protect` complete (Protect: 30
operations, 0 failed, wipe passed the post-wait inventory), `degdid-block-wlidsvc-v2` is
scoped to `login.live.com`'s 8 resolved IPs (not `Any`) and enforced, `-RefreshMintScope`
re-scopes cleanly and leaves no staging rule behind, Status reports `ProtectedNoRealGdid`,
and the VM keeps internet throughout. The full Pester suite passes (71 passed, 0 failed),
including new coverage for the answer filter and the mint-scope refresh. The flag-off path
is byte-identical to before (verified by diff).
