### PR TITLE
Scope the identity-service snapshot to the named services

### DIFF
--- a/degdid.ps1
+++ b/degdid.ps1
@@ -2909,6 +2909,20 @@ function Get-GdidInventory {
   }
 }
 
+function Select-BlockingServiceError {
+  # A named identity service that is simply absent on this build is benign
+  # (NoServiceFoundForGivenName): there is nothing to quiesce, so it is skipped.
+  # Any other query failure - e.g. a present service whose ACL denies status
+  # access - is blocking and must fail the snapshot closed so the wipe never
+  # proceeds while one of these might still be running.
+  param([AllowNull()][object[]]$ServiceErrors)
+
+  return @(
+    $ServiceErrors |
+      Where-Object { $_.FullyQualifiedErrorId -notlike 'NoServiceFoundForGivenName*' }
+  )
+}
+
 function Get-GdidServiceSnapshot {
   $wanted = @('wlidsvc', 'CDPSvc', 'TokenBroker', 'CDPUserSvc*')
   try {
@@ -2916,14 +2930,7 @@ function Get-GdidServiceSnapshot {
       Get-Service -Name $wanted -ErrorAction SilentlyContinue -ErrorVariable serviceErrors |
         Sort-Object Name
     )
-    # A named identity service that is simply absent on this build is benign: there
-    # is nothing to quiesce, so skip it. Any other query failure - e.g. a present
-    # service whose ACL denies status access - must fail closed: the wipe cannot
-    # proceed while one of these might still be running.
-    $blocking = @(
-      $serviceErrors |
-        Where-Object { $_.FullyQualifiedErrorId -notlike 'NoServiceFoundForGivenName*' }
-    )
+    $blocking = @(Select-BlockingServiceError -ServiceErrors $serviceErrors)
     if ($blocking.Count -gt 0) {
       throw 'Identity services could not be queried: {0}' -f (
         ($blocking | ForEach-Object { $_.Exception.Message }) -join '; '

--- a/degdid.ps1
+++ b/degdid.ps1
@@ -2910,14 +2910,25 @@ function Get-GdidInventory {
 }
 
 function Get-GdidServiceSnapshot {
+  $wanted = @('wlidsvc', 'CDPSvc', 'TokenBroker', 'CDPUserSvc*')
   try {
     $services = @(
-      Get-Service -ErrorAction Stop |
-        Where-Object {
-          $_.Name -match '^(wlidsvc|CDPSvc|TokenBroker|CDPUserSvc.*)$'
-        } |
+      Get-Service -Name $wanted -ErrorAction SilentlyContinue -ErrorVariable serviceErrors |
         Sort-Object Name
     )
+    # A named identity service that is simply absent on this build is benign: there
+    # is nothing to quiesce, so skip it. Any other query failure - e.g. a present
+    # service whose ACL denies status access - must fail closed: the wipe cannot
+    # proceed while one of these might still be running.
+    $blocking = @(
+      $serviceErrors |
+        Where-Object { $_.FullyQualifiedErrorId -notlike 'NoServiceFoundForGivenName*' }
+    )
+    if ($blocking.Count -gt 0) {
+      throw 'Identity services could not be queried: {0}' -f (
+        ($blocking | ForEach-Object { $_.Exception.Message }) -join '; '
+      )
+    }
     $unstable = @(
       $services |
         Where-Object { $_.Status -notin @('Running', 'Stopped') }

--- a/tests/degdid.Tests.ps1
+++ b/tests/degdid.Tests.ps1
@@ -990,3 +990,66 @@ Describe 'degdid Unblock sequencing' {
     Assert-MockCalled Invoke-DnsFlush 0 -Scope It
   }
 }
+
+Describe 'degdid identity service snapshot' {
+  It 'maps running state and start type for present services' {
+    Mock Get-Service {
+      [pscustomobject]@{ Name = 'wlidsvc'; Status = 'Running'; StartType = 'Manual' }
+      [pscustomobject]@{ Name = 'CDPSvc';  Status = 'Stopped'; StartType = 'Automatic' }
+    }
+    $snap = Get-GdidServiceSnapshot
+    $snap.Success | Should Be $true
+    @($snap.Services).Count | Should Be 2
+    (@($snap.Services) | Where-Object { $_.Name -eq 'wlidsvc' }).WasRunning | Should Be $true
+    (@($snap.Services) | Where-Object { $_.Name -eq 'CDPSvc' }).WasRunning | Should Be $false
+  }
+
+  It 'fails closed when an identity service is in a transitional state' {
+    Mock Get-Service {
+      [pscustomobject]@{ Name = 'wlidsvc'; Status = 'StartPending'; StartType = 'Manual' }
+    }
+    $snap = Get-GdidServiceSnapshot
+    $snap.Success | Should Be $false
+    $snap.Error | Should Match 'transitional'
+  }
+}
+
+Describe 'degdid blocking-service classification' {
+  function New-TestServiceError {
+    param(
+      [string]$FullyQualifiedErrorId,
+      [string]$Message = 'error'
+    )
+    return New-Object System.Management.Automation.ErrorRecord(
+      [System.Exception]::new($Message),
+      $FullyQualifiedErrorId,
+      [System.Management.Automation.ErrorCategory]::NotSpecified,
+      $null
+    )
+  }
+
+  It 'treats an absent-service error as non-blocking' {
+    $rec = New-TestServiceError `
+      -FullyQualifiedErrorId 'NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.GetServiceCommand'
+    @(Select-BlockingServiceError -ServiceErrors @($rec)).Count | Should Be 0
+  }
+
+  It 'treats any other query error as blocking' {
+    $rec = New-TestServiceError `
+      -FullyQualifiedErrorId 'PermissionDenied,Microsoft.PowerShell.Commands.GetServiceCommand' `
+      -Message 'Access is denied.'
+    @(Select-BlockingServiceError -ServiceErrors @($rec)).Count | Should Be 1
+  }
+
+  It 'keeps only the blocking error from a mixed set' {
+    $absent = New-TestServiceError -FullyQualifiedErrorId 'NoServiceFoundForGivenName,X'
+    $denied = New-TestServiceError -FullyQualifiedErrorId 'PermissionDenied,X' -Message 'Access is denied.'
+    $blocking = @(Select-BlockingServiceError -ServiceErrors @($absent, $denied))
+    $blocking.Count | Should Be 1
+    $blocking[0].Exception.Message | Should Be 'Access is denied.'
+  }
+
+  It 'returns nothing when there are no errors' {
+    @(Select-BlockingServiceError -ServiceErrors @()).Count | Should Be 0
+  }
+}


### PR DESCRIPTION
Fixes #1

### Problem
`Get-GdidServiceSnapshot` enumerates every service with `Get-Service`, then filters down
to the four identity services it quiesces (`wlidsvc`, `CDPSvc`, `TokenBroker`,
`CDPUserSvc*`). The filter runs after enumeration, so an unrelated service can break the
snapshot before it is ever reached. On some builds `PrintNotify` (Printer Extensions and
Notifications) carries an ACL that denies status queries even to an administrator;
`Get-Service` raises that error during enumeration, `-ErrorAction Stop` escalates it to
terminating, and the snapshot fails closed. `-Protect` then aborts the device inventory
before any mutation ("Identity services could not be inventoried; no mutation was
attempted"), even though the identity services themselves are reachable.

### Change
Query the four services by name with `Get-Service -Name` instead of enumerating all of
them, so unrelated services like `PrintNotify` are never opened. The call uses
`-ErrorAction SilentlyContinue -ErrorVariable` so the errors can be classified rather than
blindly swallowed: a named service that is absent on this build
(`NoServiceFoundForGivenName`) is benign and skipped, since there is nothing to quiesce,
while any other query failure, such as a present identity service whose ACL denies access,
still fails closed so a wipe never proceeds with one of these services potentially left
running. The transitional-state check and the rest of the snapshot are unchanged.

The absent-vs-blocking rule is extracted into a small pure helper,
`Select-BlockingServiceError`, so the security-critical invariant can be unit-tested
directly. This is behavior-preserving; it exists because Pester cannot feed a mocked
`Get-Service`'s errors into the caller's `-ErrorVariable`, so the classification is not
otherwise reachable from a test.

On a machine where the four services are present and queryable, the resulting snapshot is
identical to before.

### Testing
Verified on Windows 11 24H2 (build 26100), PowerShell 7.6.4: `-Protect` runs the snapshot
in place and completes cleanly (30 operations, 0 failed, wipe passed the post-wait
inventory), and `-Status` reports `PROTECTED`. All four identity services are present and
queryable on this box, so behavior is unchanged. The reported `PermissionDenied` is
specific to the reporter's build (26200) and could not be reproduced locally, but the fix
removes the all-service enumeration that surfaced it: the snapshot now opens only the four
identity services, so an unrelated service's ACL can no longer abort the inventory.

Unit tests added (`Invoke-Pester`, Pester 4.10.1, full suite green): `Select-BlockingServiceError`
classifies an absent-service error (`NoServiceFoundForGivenName`) as non-blocking and any
other query error as blocking, with mixed-set and empty-input cases; plus snapshot-level
coverage for the running-state projection and the transitional-state fail-closed path.
