### PR TITLE
Scope MDM detection to enrollment-backed OMADM accounts

### DIFF
--- a/degdid.ps1
+++ b/degdid.ps1
@@ -1676,9 +1676,55 @@ function Get-DsregJoinState {
   }
 }
 
+function Get-NormalizedEnrollmentGuid {
+  param([AllowNull()][string]$Name)
+  if (-not $Name) { return $null }
+  return $Name.Trim('{', '}').ToLowerInvariant()
+}
+
+function Test-RealMdmEnrollmentEntry {
+  # A genuine server-backed enrollment has an active state plus a real server or
+  # user binding. Windows internal CSPs (Local/Cloud/Deploy Authority) and the
+  # FFFFFFFF-... fake/local placeholder carry neither, so they fail here.
+  param(
+    [AllowNull()][string[]]$ValueNames,
+    [AllowNull()][object]$EnrollmentState,
+    [AllowNull()][object]$Upn,
+    [AllowNull()][object]$DiscoveryUrl
+  )
+  if (-not (@($ValueNames) -contains 'EnrollmentState')) { return $false }
+  $state = 0
+  if (-not [int]::TryParse([string]$EnrollmentState, [ref]$state)) { return $false }
+  if ($state -ne 1) { return $false }
+  return [bool]$Upn -or [bool]$DiscoveryUrl
+}
+
+function Select-CorroboratedOmadmAccount {
+  # An OMADM account only counts as MDM evidence when its GUID matches a real
+  # enrollment. This rejects the well-known FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
+  # placeholder (a fake/local marker that stock and NTLite-imaged Windows carry
+  # without a paired real enrollment) and any other uncorroborated stub.
+  param(
+    [AllowNull()][string[]]$OmadmAccountIds,
+    [AllowNull()][string[]]$RealEnrollmentIds
+  )
+  $real = @{}
+  foreach ($id in @($RealEnrollmentIds)) {
+    $n = Get-NormalizedEnrollmentGuid -Name $id
+    if ($n) { $real[$n] = $true }
+  }
+  return @(
+    @($OmadmAccountIds) | Where-Object {
+      $n = Get-NormalizedEnrollmentGuid -Name $_
+      $n -and $real.ContainsKey($n)
+    }
+  )
+}
+
 function Get-MdmEnrollmentState {
   $evidence = 0
   try {
+    $realEnrollmentIds = New-Object System.Collections.Generic.List[string]
     $enrollmentsPath = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Enrollments'
     if (Test-Path -LiteralPath $enrollmentsPath -ErrorAction Stop) {
       foreach (
@@ -1690,24 +1736,29 @@ function Get-MdmEnrollmentState {
         )
       ) {
         $item = Get-Item -LiteralPath $key.PSPath -ErrorAction Stop
-        $names = @($item.GetValueNames())
-        $upn = $item.GetValue('UPN', $null)
-        $discovery = $item.GetValue('DiscoveryServiceFullURL', $null)
-        $state = $item.GetValue('EnrollmentState', $null)
         if (
-          $names -contains 'EnrollmentState' -and
-          [int]$state -eq 1 -and
-          ($upn -or $discovery)
+          Test-RealMdmEnrollmentEntry `
+            -ValueNames @($item.GetValueNames()) `
+            -EnrollmentState $item.GetValue('EnrollmentState', $null) `
+            -Upn $item.GetValue('UPN', $null) `
+            -DiscoveryUrl $item.GetValue('DiscoveryServiceFullURL', $null)
         ) {
-          $evidence++
+          [void]$realEnrollmentIds.Add($key.PSChildName)
         }
       }
     }
+    $evidence += $realEnrollmentIds.Count
 
     $omadmPath = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Provisioning\OMADM\Accounts'
     if (Test-Path -LiteralPath $omadmPath -ErrorAction Stop) {
+      $omadmIds = @(
+        Get-ChildItem -LiteralPath $omadmPath -ErrorAction Stop |
+          ForEach-Object { $_.PSChildName }
+      )
       $evidence += @(
-        Get-ChildItem -LiteralPath $omadmPath -ErrorAction Stop
+        Select-CorroboratedOmadmAccount `
+          -OmadmAccountIds $omadmIds `
+          -RealEnrollmentIds @($realEnrollmentIds)
       ).Count
     }
 

--- a/tests/degdid.Tests.ps1
+++ b/tests/degdid.Tests.ps1
@@ -990,3 +990,163 @@ Describe 'degdid Unblock sequencing' {
     Assert-MockCalled Invoke-DnsFlush 0 -Scope It
   }
 }
+
+function New-TestRegKey {
+  param(
+    [string]$ChildName,
+    [hashtable]$Values = @{}
+  )
+  $key = [pscustomobject]@{
+    PSChildName = $ChildName
+    PSPath = "TestRegistry::$ChildName"
+    _values = $Values
+  }
+  $key |
+    Add-Member -MemberType ScriptMethod -Name GetValueNames -Value {
+      @($this._values.Keys)
+    } -PassThru |
+    Add-Member -MemberType ScriptMethod -Name GetValue -Value {
+      param($name, $default)
+      if ($this._values.ContainsKey($name)) { return $this._values[$name] }
+      return $default
+    } -PassThru
+}
+
+Describe 'degdid MDM enrollment classification' {
+  $fakeGuid = 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'
+  $realGuid = 'A1B2C3D4-1111-2222-3333-444455556666'
+
+  It 'accepts an active enrollment bound by UPN' {
+    (Test-RealMdmEnrollmentEntry `
+        -ValueNames @('EnrollmentState', 'UPN') `
+        -EnrollmentState 1 `
+        -Upn 'user@contoso.com' `
+        -DiscoveryUrl $null) | Should Be $true
+  }
+
+  It 'accepts an active enrollment bound by discovery URL' {
+    (Test-RealMdmEnrollmentEntry `
+        -ValueNames @('EnrollmentState', 'DiscoveryServiceFullURL') `
+        -EnrollmentState 1 `
+        -Upn $null `
+        -DiscoveryUrl 'https://enrollment.manage.microsoft.com/enrollmentserver/discovery.svc') |
+      Should Be $true
+  }
+
+  It 'rejects an active entry with no server or user binding' {
+    (Test-RealMdmEnrollmentEntry `
+        -ValueNames @('EnrollmentState') `
+        -EnrollmentState 1 `
+        -Upn $null `
+        -DiscoveryUrl $null) | Should Be $false
+  }
+
+  It 'rejects a not-yet-active enrollment' {
+    (Test-RealMdmEnrollmentEntry `
+        -ValueNames @('EnrollmentState', 'UPN') `
+        -EnrollmentState 0 `
+        -Upn 'user@contoso.com' `
+        -DiscoveryUrl $null) | Should Be $false
+  }
+
+  It 'rejects an entry without an EnrollmentState value' {
+    (Test-RealMdmEnrollmentEntry `
+        -ValueNames @('UPN') `
+        -EnrollmentState $null `
+        -Upn 'user@contoso.com' `
+        -DiscoveryUrl $null) | Should Be $false
+  }
+
+  It 'excludes the FFFF placeholder when no real enrollment corroborates it' {
+    $selected = @(
+      Select-CorroboratedOmadmAccount `
+        -OmadmAccountIds @($fakeGuid) `
+        -RealEnrollmentIds @()
+    )
+    $selected.Count | Should Be 0
+  }
+
+  It 'includes an OMADM account backed by a real enrollment' {
+    $selected = @(
+      Select-CorroboratedOmadmAccount `
+        -OmadmAccountIds @($realGuid) `
+        -RealEnrollmentIds @($realGuid)
+    )
+    $selected.Count | Should Be 1
+  }
+
+  It 'matches GUIDs irrespective of brace and case formatting' {
+    $selected = @(
+      Select-CorroboratedOmadmAccount `
+        -OmadmAccountIds @($realGuid.ToLowerInvariant()) `
+        -RealEnrollmentIds @('{' + $realGuid.ToUpperInvariant() + '}')
+    )
+    $selected.Count | Should Be 1
+  }
+
+  It 'excludes an OMADM account absent from the real enrollment set' {
+    $selected = @(
+      Select-CorroboratedOmadmAccount `
+        -OmadmAccountIds @($realGuid) `
+        -RealEnrollmentIds @('99999999-0000-0000-0000-000000000000')
+    )
+    $selected.Count | Should Be 0
+  }
+
+  It 'keeps only corroborated accounts from a mixed set' {
+    $selected = @(
+      Select-CorroboratedOmadmAccount `
+        -OmadmAccountIds @($fakeGuid, $realGuid) `
+        -RealEnrollmentIds @($realGuid)
+    )
+    $selected.Count | Should Be 1
+    $selected[0] | Should Be $realGuid
+  }
+
+  It 'reports not-enrolled on a clean machine carrying only the OMADM placeholder' {
+    # Issue #8 repro: stock/NTLite-imaged Windows 11 25H2 exposes internal CSP
+    # enrollments (no UPN/Discovery) plus the FFFF fake/local OMADM stub. None
+    # is a real enrollment, so the verdict must stay eligible.
+    $internalCsp = New-TestRegKey -ChildName '11111111-2222-3333-4444-555566667777' -Values @{
+      EnrollmentState = 1
+    }
+    $fakeEnrollment = New-TestRegKey -ChildName $fakeGuid -Values @{ ProtoVer = '1.2' }
+    $enrollmentKeys = @($internalCsp, $fakeEnrollment)
+    $omadmKeys = @(New-TestRegKey -ChildName $fakeGuid)
+    $itemsByPath = @{}
+    foreach ($k in $enrollmentKeys) { $itemsByPath[$k.PSPath] = $k }
+
+    Mock Test-Path { $true } -ParameterFilter {
+      $LiteralPath -like '*\Enrollments' -or $LiteralPath -like '*OMADM\Accounts'
+    }
+    Mock Get-ChildItem { $enrollmentKeys } -ParameterFilter { $LiteralPath -like '*\Enrollments' }
+    Mock Get-ChildItem { $omadmKeys } -ParameterFilter { $LiteralPath -like '*OMADM\Accounts' }
+    Mock Get-Item { $itemsByPath[$LiteralPath] }
+
+    $state = Get-MdmEnrollmentState
+    $state.Known | Should Be $true
+    $state.Enrolled | Should Be $false
+    $state.EvidenceCount | Should Be 0
+  }
+
+  It 'reports enrolled for a genuine server-backed enrollment' {
+    $realEnrollment = New-TestRegKey -ChildName $realGuid -Values @{
+      EnrollmentState = 1
+      UPN = 'user@contoso.com'
+    }
+    $enrollmentKeys = @($realEnrollment)
+    $omadmKeys = @(New-TestRegKey -ChildName $realGuid)
+    $itemsByPath = @{ $realEnrollment.PSPath = $realEnrollment }
+
+    Mock Test-Path { $true } -ParameterFilter {
+      $LiteralPath -like '*\Enrollments' -or $LiteralPath -like '*OMADM\Accounts'
+    }
+    Mock Get-ChildItem { $enrollmentKeys } -ParameterFilter { $LiteralPath -like '*\Enrollments' }
+    Mock Get-ChildItem { $omadmKeys } -ParameterFilter { $LiteralPath -like '*OMADM\Accounts' }
+    Mock Get-Item { $itemsByPath[$LiteralPath] }
+
+    $state = Get-MdmEnrollmentState
+    $state.Known | Should Be $true
+    $state.Enrolled | Should Be $true
+  }
+}


### PR DESCRIPTION
Fixes #8

### Problem
On a machine that was never MDM-enrolled, `-Status` can report "MDM-enrolled systems are
unsupported" and refuse to run. `Get-MdmEnrollmentState` counts every child of
`HKLM\SOFTWARE\Microsoft\Provisioning\OMADM\Accounts` as enrollment evidence, so the
well-known `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF` placeholder -- a local/fake-enrollment
stub that stock and NTLite-imaged Windows carry, not a real enrollment -- is enough on its
own to trip the verdict. Reported on Windows 11 25H2 in #8.

The sibling `Enrollments` check is already careful: it counts an entry only when it is
active (`EnrollmentState == 1`) and has a real binding (a `UPN` or a
`DiscoveryServiceFullURL`). The OMADM branch never got the same rigor.

### Change
Count an OMADM account only when its GUID matches an enrollment that passes that same
real-enrollment test (correlation). A genuine server-backed enrollment always writes both
an `Enrollments\<GUID>` and a paired `OMADM\Accounts\<GUID>`; the placeholder and the
internal CSP entries under `Enrollments` have no such passing match, so they no longer
register. Genuine MDM is unaffected -- it is still detected by the `Enrollments` branch and
is now corroborated by OMADM rather than counted from an unverified source.

The decision is extracted into two pure helpers so the security-relevant classification is
unit-testable off-Windows: `Test-RealMdmEnrollmentEntry` (is one `Enrollments` entry a
genuine, active, bound enrollment -- logically identical to the previous inline test) and
`Select-CorroboratedOmadmAccount` (keep only OMADM GUIDs that match a real enrollment,
brace/case-insensitive).

One small behavior change: the extracted predicate parses `EnrollmentState` with
`[int]::TryParse` instead of the previous `[int]` cast, so a malformed value skips just
that entry rather than throwing and failing the whole check closed. `EnrollmentState` is
always a DWORD in practice, so this is a no-op in the field.

On a machine with genuine enrollments and no stray placeholder, the result is identical to
before.

### Design notes
Correlation is preferred over hard-coding the `FFFFFFFF-...` GUID or inspecting the
account's `AcctUId`: it reuses the enrollment test already trusted for primary detection,
rejects any uncorroborated stub (not just the one known GUID), and needs no assumptions
about the OMADM value schema. Because a real enrollment is already detected by the
`Enrollments` branch, tightening OMADM cannot make a genuinely managed machine read as
unmanaged.

### Testing
Verified on Windows 11 24H2 (build 26100), PowerShell 7.6.4: the full Pester suite passes
(75 passed, 0 failed, Pester 4.10.1). 24H2 does not ship the 25H2 placeholder, so the exact
failure shape was reproduced by adding a throwaway OMADM account with no paired enrollment:
`Get-MdmEnrollmentState` leaves the verdict eligible (`Enrolled = False`, `EvidenceCount`
unchanged) where the old code would have counted it, and the machine's 24 internal-CSP
`Enrollments` entries all classify as non-real.

Unit tests added (`Describe 'degdid MDM enrollment classification'`, 12 tests): the two
pure classifiers (active/bound vs not, brace/case-insensitive matching, mixed and empty
sets), plus a mocked issue #8 repro (clean machine carrying only the placeholder -> not
enrolled) and the inverse (a real, server-backed enrollment -> enrolled).
