### PR TITLE
fix(firewall): let Unblock complete without dynamic-keyword cmdlets

### DIFF
--- a/degdid.ps1
+++ b/degdid.ps1
@@ -1398,12 +1398,33 @@ function Set-FirewallBlock {
   }
 }
 
+function Get-ManagedFirewallRuleRemainders {
+  # Enumerate with -ErrorAction Stop and filter client-side so a provider
+  # failure cannot be mistaken for "no rules remain". A bare -Name probe
+  # errors when nothing matches, which is indistinguishable from a real
+  # enumeration failure without inspecting error categories.
+  $managedNames = @(
+    $script:FirewallRuleName,
+    $script:MintServiceRuleName,
+    $script:StagingMintServiceRuleName
+  )
+  return @(
+    Get-NetFirewallRule -PolicyStore ActiveStore -ErrorAction Stop |
+      Where-Object { $managedNames -contains $_.Name }
+  )
+}
+
 function Remove-FirewallBlock {
   param([switch]$DryRun)
 
+  $ruleCmdletsAvailable = (
+    [bool](Get-Command Get-NetFirewallRule -ErrorAction SilentlyContinue) -and
+    [bool](Get-Command Remove-NetFirewallRule -ErrorAction SilentlyContinue)
+  )
+
   if ($DryRun) {
     return [pscustomobject]@{
-      Success = Test-DynamicFirewallSupport
+      Success = $ruleCmdletsAvailable
       DryRun = $true
       Message = 'Would remove current managed firewall rules and keywords.'
       State = Get-FirewallState
@@ -1411,20 +1432,23 @@ function Remove-FirewallBlock {
   }
 
   try {
-    if (
-      -not (Get-Command Get-NetFirewallRule -ErrorAction SilentlyContinue) -or
-      -not (Get-Command Remove-NetFirewallRule -ErrorAction SilentlyContinue)
-    ) {
+    if (-not $ruleCmdletsAvailable) {
       throw 'Firewall rule cmdlets are unavailable.'
     }
     Remove-ManagedFirewallRules
     Remove-StagingMintServiceRule
 
-    if (-not (Test-DynamicFirewallSupport)) {
-      throw 'Dynamic-keyword cmdlets are unavailable; keyword cleanup cannot verify.'
-    }
-    foreach ($hostName in $script:BlockHosts) {
-      Remove-DegdidDynamicKeyword -HostName $hostName
+    # degdid can only have created dynamic-keyword state on systems where the
+    # dynamic-keyword cmdlets exist (Windows 11 22H2 and newer). On supported
+    # builds without them (Windows 10 19045, Windows 11 before 22H2) no
+    # keyword state can exist, so the missing cmdlets must not strand the
+    # Unblock recovery path.
+    $keywordCleanup = 'SkippedCmdletsUnavailable'
+    if (Test-DynamicFirewallSupport) {
+      foreach ($hostName in $script:BlockHosts) {
+        Remove-DegdidDynamicKeyword -HostName $hostName
+      }
+      $keywordCleanup = 'Removed'
     }
   } catch {
     return [pscustomobject]@{
@@ -1435,11 +1459,37 @@ function Remove-FirewallBlock {
     }
   }
 
+  # Verify rule removal with the universally available rule cmdlets rather
+  # than Get-FirewallState, whose Health is 'Unavailable' on systems without
+  # dynamic-keyword support even when no managed state remains. Enumeration
+  # failures are fail-closed: they are indistinguishable from leftover rules.
   $state = Get-FirewallState
+  try {
+    $remainingRules = @(Get-ManagedFirewallRuleRemainders)
+  } catch {
+    return [pscustomobject]@{
+      Success = $false
+      DryRun = $false
+      Message = 'Managed firewall rules could not be enumerated: {0}' -f
+        $_.Exception.Message
+      KeywordCleanup = $keywordCleanup
+      State = $state
+    }
+  }
+  $keywordsCleared = (
+    $keywordCleanup -eq 'SkippedCmdletsUnavailable' -or
+    ($state.KeywordCount -eq 0 -and $state.Errors.Count -eq 0)
+  )
+  $success = ($remainingRules.Count -eq 0 -and $keywordsCleared)
   return [pscustomobject]@{
-    Success = $state.Health -eq 'Absent'
+    Success = $success
     DryRun = $false
-    Message = 'Managed firewall rules and keywords removed.'
+    Message = $(if ($success) {
+      'Managed firewall rules and keywords removed.'
+    } else {
+      'Managed firewall state remains after cleanup.'
+    })
+    KeywordCleanup = $keywordCleanup
     State = $state
   }
 }

--- a/tests/degdid.Tests.ps1
+++ b/tests/degdid.Tests.ps1
@@ -990,3 +990,169 @@ Describe 'degdid Unblock sequencing' {
     Assert-MockCalled Invoke-DnsFlush 0 -Scope It
   }
 }
+
+Describe 'degdid firewall removal without dynamic-keyword cmdlets' {
+  # Windows 10 19045 and Windows 11 builds before 22H2 are supported targets
+  # but have no Get/New/Remove-NetFirewallDynamicKeywordAddress cmdlets, so
+  # Block never creates firewall state there. Unblock must still complete.
+
+  It 'succeeds when dynamic-keyword cmdlets are unavailable and no rules exist' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $false }
+    Mock Get-NetFirewallRule {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $false
+        Health = 'Unavailable'
+        KeywordCount = 0
+        Errors = @()
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $true
+    $result.KeywordCleanup | Should Be 'SkippedCmdletsUnavailable'
+    $result.Message | Should Match 'removed'
+  }
+
+  It 'reports DryRun success when dynamic-keyword cmdlets are unavailable' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $false }
+    Mock Get-FirewallState {
+      [pscustomobject]@{ Available = $false; Health = 'Unavailable' }
+    }
+
+    (Remove-FirewallBlock -DryRun).Success | Should Be $true
+  }
+
+  It 'fails closed when a managed rule survives removal' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $false }
+    Mock Get-NetFirewallRule {
+      [pscustomobject]@{ Name = 'degdid-block-fqdn-v2' }
+    }
+    Mock Remove-ManagedFirewallRules {}
+    Mock Remove-StagingMintServiceRule {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $false
+        Health = 'Unavailable'
+        KeywordCount = 0
+        Errors = @()
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $false
+    $result.Message | Should Match 'remains'
+  }
+
+  It 'fails closed when rule enumeration errors during verification' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $false }
+    Mock Get-NetFirewallRule { throw 'provider failed' }
+    Mock Remove-ManagedFirewallRules {}
+    Mock Remove-StagingMintServiceRule {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $false
+        Health = 'Unavailable'
+        KeywordCount = 0
+        Errors = @()
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $false
+    $result.Message | Should Match 'could not be enumerated'
+  }
+
+  It 'cleans keywords when dynamic-keyword cmdlets are available' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-NetFirewallRule {}
+    Mock Remove-DegdidDynamicKeyword {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $true
+        Health = 'Absent'
+        KeywordCount = 0
+        Errors = @()
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $true
+    $result.KeywordCleanup | Should Be 'Removed'
+    Assert-MockCalled Remove-DegdidDynamicKeyword 11 -Scope It
+  }
+
+  It 'fails closed when keywords survive removal' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-NetFirewallRule {}
+    Mock Remove-DegdidDynamicKeyword {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $true
+        Health = 'Malformed'
+        KeywordCount = 2
+        Errors = @()
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $false
+  }
+
+  It 'fails closed when keyword state cannot be enumerated' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $true }
+    Mock Get-NetFirewallRule {}
+    Mock Remove-DegdidDynamicKeyword {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $true
+        Health = 'Error'
+        KeywordCount = 0
+        Errors = @('Keywords: provider failed')
+      }
+    }
+
+    $result = Remove-FirewallBlock
+    $result.Success | Should Be $false
+  }
+
+  It 'unblocks hosts on a dynamic-keyword-less system end to end' {
+    Mock Get-Command { $true }
+    Mock Test-DynamicFirewallSupport { $false }
+    Mock Get-NetFirewallRule {}
+    Mock Get-FirewallState {
+      [pscustomobject]@{
+        Available = $false
+        Health = 'Unavailable'
+        KeywordCount = 0
+        Errors = @()
+      }
+    }
+    $script:unblockCalls = New-Object System.Collections.Generic.List[string]
+    Mock Invoke-HostsDocumentChange {
+      param($Mode, $DryRun)
+      [void]$script:unblockCalls.Add(
+        $(if ($DryRun) { 'hosts-preflight' } else { 'hosts-remove' })
+      )
+      [pscustomobject]@{ Mode = $Mode; DryRun = [bool]$DryRun }
+    }
+    Mock Invoke-DnsFlush {
+      [void]$script:unblockCalls.Add('dns-flush')
+    }
+    Mock Read-HostsDocument {
+      [pscustomobject]@{ State = [pscustomobject]@{ State = 'Absent' } }
+    }
+
+    $result = Invoke-UnblockConfiguration
+    $result.Success | Should Be $true
+    ($script:unblockCalls -join ',') |
+      Should Be 'hosts-preflight,hosts-remove,dns-flush'
+  }
+}


### PR DESCRIPTION
## What does this PR do

Fixes `-Unblock` on supported Windows builds that don't ship the dynamic-keyword firewall cmdlets (Windows 10 19045, Windows 11 builds before 22H2).

On those systems today:

- `-Block` succeeds — the firewall layer is optional and skipped (`Set-FirewallBlock` reports the cmdlets unavailable, `Invoke-BlockConfiguration` warns and continues), so the hosts block applies and **no degdid firewall state can ever exist**;
- but `-Unblock` always fails with exit 3 (`Dynamic-keyword cmdlets are unavailable; keyword cleanup cannot verify.`) and refuses to remove the hosts region, leaving `login.live.com`, `account.live.com`, and the DDS endpoints pinned to `0.0.0.0`/`::` with no recovery path short of hand-editing `C:\Windows\System32\drivers\etc\hosts`.

The tool enters a hosts-only protected state on those builds but its own documented undo path demands firewall cmdlets it never needed.

`Remove-FirewallBlock` now:

- skips dynamic-keyword cleanup when the cmdlets are unavailable — degdid could only have created keyword state via `Set-FirewallBlock`, which requires the same cmdlets, so their absence cannot indicate leftover keywords;
- verifies rule removal with `Get-NetFirewallRule -PolicyStore ActiveStore` directly instead of `Get-FirewallState.Health -eq 'Absent'`, which is always `'Unavailable'` on those builds even when no managed state exists;
- still fails closed when managed rules survive removal, when keywords survive cleanup, or when rule/keyword state cannot be enumerated (an enumeration error is indistinguishable from leftover rules, so it is a failure, never a pass);
- reports DryRun firewall-side success based on the rule cmdlets, matching the real run.

On Windows 11 22H2+ the flow is unchanged: keywords are removed and verified, then the hosts region is removed.

## Related Issue

Found during code review; no upstream issue filed. Duplicate/prior-art check run 2026-08-06 against all PRs and issues (open + closed): PRs #4, #5, #7, #9 and issues #1, #2, #3, #8, #10, #11 — none touch `Remove-FirewallBlock` or the `-Unblock` path (PR #5 / issue #3 are about wlidsvc rule scoping under `-Protect`, a different layer). No PR exists from this branch head.

## Changes Made

- `degdid.ps1`: new `Get-ManagedFirewallRuleRemainders` helper — enumerates the ActiveStore with `-ErrorAction Stop` and filters client-side (a bare `-Name` probe errors when nothing matches, which would be indistinguishable from a provider failure); `Remove-FirewallBlock` reworked as described above, with the verification wrapped so enumeration errors fail closed.
- `tests/degdid.Tests.ps1`: 8 new Pester tests — success without dynamic cmdlets, DryRun parity, surviving-rule fail-closed, rule-enumeration-error fail-closed, keyword cleanup when cmdlets exist, surviving-keyword fail-closed, keyword-enumeration-error fail-closed, and an end-to-end `Invoke-UnblockConfiguration` run on a simulated cmdlet-less system.

## How to Test

- `Invoke-Pester -Path tests` with in-box Pester 3.4.0: **71/71 pass** (63 pre-existing + 8 new).
- Sabotage check 1: with `degdid.ps1` reverted to current `main`, 5 of the new tests fail (the regression pins for the `-Unblock` bug); restoring the fix returns the suite to green.
- Sabotage check 2: against an intermediate revision of this PR that verified rule removal with `-ErrorAction SilentlyContinue`, the rule-enumeration-error test fails (pins the fail-open the final revision avoids).
- `.\degdid.ps1 -Unblock -DryRun` on Windows 11 25H2 build 26200: prints the expected plan, exit 0, no state changed.
- An independent second-model review of this diff flagged one blocking issue in the first revision (the verification read suppressed errors — fail-open); that is fixed in this revision and pinned by the enumeration-error test. Review of the final revision: approve, residual notes only.

Not executed: a real Windows 10 19045 / pre-22H2 machine (none available to the author). The cmdlet-less behavior is exercised through the mocked Pester tests; the invariant the fix relies on — on builds without the dynamic-keyword cmdlets, `-Block` creates no firewall state — holds by construction in the existing code.

## Logs

```
Tests completed in 5.68s
Passed: 71 Failed: 0 Skipped: 0 Pending: 0 Inconclusive: 0

# sabotage (degdid.ps1 @ upstream main):
Passed: 65 Failed: 5  — FAILED: succeeds when dynamic-keyword cmdlets are unavailable and no rules exist;
reports DryRun success when dynamic-keyword cmdlets are unavailable; fails closed when a managed rule
survives removal; cleans keywords when dynamic-keyword cmdlets are available; unblocks hosts on a
dynamic-keyword-less system end to end

# sabotage (intermediate revision with SilentlyContinue verification):
Passed: 70 Failed: 1 — FAILED: fails closed when rule enumeration errors during verification
```
