### PR TITLE
Fix credential task registration when a SID resolves to a bare name

### DIFF
--- a/degdid.ps1
+++ b/degdid.ps1
@@ -2345,7 +2345,7 @@ function Invoke-TargetDeviceCredentialOperation {
   if ($accessMode -eq 'InteractiveTask') {
     return @(
       Invoke-CredentialTask `
-        -UserId $Target.Sid `
+        -UserId $Target.AccountName `
         -LogonType Interactive `
         -RunLevel Limited `
         -ResultDirectory (Join-Path $Target.ProfilePath 'AppData\Local\Temp') `


### PR DESCRIPTION
New-ScheduledTaskPrincipal -UserId resolves a SID to an unqualified
account name on some systems ("Nitro" rather than "NITRO\Nitro").
Task Scheduler rejects that value during Register-ScheduledTask with
"The parameter is incorrect. (10,8):UserId:", which surfaces as:

  TargetUserDeviceCredentials: The parameter is incorrect.

That error lands in the inventory error list, so Invoke-IdentityMutation
aborts at the pre-mutation inventory and neither Wipe nor Decoy can
complete. Status also reports INCOMPLETE, because the target-user
credential vault can never be inspected.

Pass $Target.AccountName instead. It is already derived from
Win32_ComputerSystem.UserName and validated through NTAccount.Translate(),
so the principal is expressed as MACHINE\User, which Task Scheduler
accepts. Invoke-SystemDeviceCredentialOperation was unaffected because it
passes a literal name rather than a SID.

Verified on Windows 11 25H2 build 26200: credential inspection succeeds,
Status reports a complete verdict, and Protect/Wipe run to completion.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
